### PR TITLE
Always keep the version of StrongSwan updated

### DIFF
--- a/one-key-ikev2.sh
+++ b/one-key-ikev2.sh
@@ -166,7 +166,7 @@ function download_files(){
     if [ -f strongswan.tar.gz ];then
         echo -e "strongswan.tar.gz [\033[32;1mfound\033[0m]"
     else
-        if ! wget https://download.strongswan.org/strongswan-5.2.1.tar.gz;then
+        if ! wget https://download.strongswan.org/strongswan.tar.gz;then
             echo "Failed to download strongswan.tar.gz"
             exit 1
         fi


### PR DESCRIPTION
Removed the specific version number of StrongSwan from link address (https://download.strongswan.org/), to keep the StrongSwan always updated.