### PR TITLE
添加了在树莓派上的支持

### DIFF
--- a/one-key-ikev2.sh
+++ b/one-key-ikev2.sh
@@ -99,6 +99,8 @@ function get_system(){
         system_str="1"
     elif  grep -Eqi "Debian" /etc/issue || grep -Eq "Debian" /etc/*-release; then
         system_str="1"
+    elif  grep -Eqi "Raspbian" /etc/issue || grep -Eq "Raspbian" /etc/*-release; then
+        system_str="1"
     else
         echo "This Script must be running at the CentOS or Ubuntu or Debian!"
         exit 1


### PR DESCRIPTION
树莓派跟Debian相同，标识符直接改为Raspbian就可以完成安装并正常工作,
这样就可以在自家路由器插个树莓派搞VPN了。
(已经在树莓派3B上测试）